### PR TITLE
Release/validate variables

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -5,7 +5,7 @@ module "remediation" {
   name             = "vulne-soldier-compliance-remediate"
   environment      = "dev"
   aws_region       = "us-east-1"
-  account_id       = "2132323212_dummmmy"
+  account_id       = "111122223333"
   lambda_log_group = "/aws/lambda/vulne-soldier-compliance-remediate"
   lambda_zip       = "../../lambda.zip"
   remediation_options = {

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,6 @@ provider "aws" {
 locals {
   function_name     = "${var.name}-${var.environment}"
   ssm_document_name = "${var.name}-inspector-findings-${var.environment}"
-  # You can specify the vulnerability severities to filter findings: default is CRITICAL and HIGH vulnerabilities
   lambda_zip        = var.lambda_zip
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,21 +1,28 @@
 variable "name" {
   description = "Name of the application"
   type        = string
+  default = "vulne-soldier-compliance-remediate"
 }
 
 variable "aws_region" {
   description = "AWS region where the resources will be created"
   type        = string
+  default = "us-east-1"
 }
 
 variable "environment" {
   description = "Name of the environment"
   type        = string
+  default = "dev"
 }
 
 variable "account_id" {
   description = "AWS account ID"
   type        = string
+  validation {
+    condition     = can(regex("^[0-9]{12}$", var.account_id))
+    error_message = "The account_id must be a 12-digit number."
+  }
 }
 
 variable "lambda_log_group" {
@@ -26,7 +33,10 @@ variable "lambda_log_group" {
 variable "lambda_zip" {
   description = "File location of the lambda zip file for remediation."
   type        = string
-  default     = null
+  validation {
+    condition     = can(regex("^.+\\.zip$", var.lambda_zip))
+    error_message = "The lambda_zip must be a path to a zip file."
+  }
 }
 
 variable "remediation_options" {
@@ -46,5 +56,13 @@ variable "remediation_options" {
     target_ec2_tag_value                       = "true"
     vulnerability_severities                   = "CRITICAL, HIGH"
     override_findings_for_target_instances_ids = null
+  }
+  validation {
+    condition     = contains(["NoReboot", "RebootIfNeeded"], var.remediation_options.reboot_option)
+    error_message = "The reboot_option must be either NoReboot or RebootIfNeeded."
+  }
+  validation {
+    condition     = can(regex("^([A-Z]+, )*[A-Z]+$", var.remediation_options.vulnerability_severities))
+    error_message = "The vulnerability_severities must be a comma-separated list of severities in uppercase."
   }
 }


### PR DESCRIPTION
This pull request includes several changes to the Terraform configuration files to improve validation and update default values. The most important changes include updating the `account_id` value, adding default values for several variables, and introducing validation rules for variables.

Updates and improvements:

* [`examples/basic/main.tf`](diffhunk://#diff-6e45d26e502f88302f69c4c196babd8939186d9cd298f94caca283c128a2d186L8-R8): Updated the `account_id` to a valid AWS account ID.

Default values addition:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR4-R25): Added default values for `name`, `aws_region`, and `environment` variables.

Validation rules introduction:

* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR4-R25): Added validation for `account_id` to ensure it is a 12-digit number.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eL29-R39): Added validation for `lambda_zip` to ensure it is a path to a zip file.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR60-R67): Added validation for `remediation_options` to ensure `reboot_option` is either `NoReboot` or `RebootIfNeeded`, and `vulnerability_severities` is a comma-separated list of uppercase severities.